### PR TITLE
Promise: Adding run commands + queuing system

### DIFF
--- a/src/promises/__tests__/promiseQueue.test.js
+++ b/src/promises/__tests__/promiseQueue.test.js
@@ -1,10 +1,12 @@
 import promiseQueue from '../promiseQueue'
-import { useFakePromises, clearFakePromises } from '../promises'
+import {
+  useFakePromises,
+  clearFakePromises,
+  runNextPromise,
+  runAllPromises,
+  runPromisesImmediately,
+} from '../promises'
 import { noop } from '../../utils/other.utils'
-
-beforeEach(() => {
-  useFakePromises()
-})
 
 afterEach(() => {
   clearFakePromises()
@@ -12,6 +14,10 @@ afterEach(() => {
 
 describe('Promise (Queue)', () => {
   describe('queue', () => {
+    beforeEach(() => {
+      useFakePromises()
+    })
+
     test('Adds a promise to the queue when a new Promise is created', () => {
       expect(promiseQueue.length).toBe(0)
       new Promise(noop)
@@ -42,6 +48,58 @@ describe('Promise (Queue)', () => {
 
       expect(spy).toHaveBeenCalledWith([p])
       spy.mockRestore()
+    })
+  })
+
+  describe('Processing', () => {
+    test('Can process promises incrementally', () => {
+      useFakePromises()
+      expect(promiseQueue.length).toBe(0)
+
+      new Promise(noop)
+      new Promise(noop)
+
+      expect(promiseQueue.length).toBe(2)
+
+      runNextPromise()
+      expect(promiseQueue.length).toBe(1)
+
+      runNextPromise()
+      expect(promiseQueue.length).toBe(0)
+
+      runNextPromise()
+      expect(promiseQueue.length).toBe(0)
+    })
+
+    test('Can process all promises', () => {
+      useFakePromises()
+      expect(promiseQueue.length).toBe(0)
+
+      new Promise(noop)
+      new Promise(noop)
+      new Promise(noop)
+
+      expect(promiseQueue.length).toBe(3)
+
+      runAllPromises()
+      expect(promiseQueue.length).toBe(0)
+
+      runNextPromise()
+      expect(promiseQueue.length).toBe(0)
+    })
+  })
+
+  describe('runPromisesImmediately', () => {
+    test('Can run promises immediately', () => {
+      useFakePromises()
+      runPromisesImmediately()
+      expect(promiseQueue.length).toBe(0)
+
+      new Promise(noop)
+      new Promise(noop)
+      new Promise(noop)
+
+      expect(promiseQueue.length).toBe(0)
     })
   })
 })

--- a/src/promises/__tests__/promiseResolver.test.js
+++ b/src/promises/__tests__/promiseResolver.test.js
@@ -1,4 +1,4 @@
-import { useFakePromises, clearFakePromises } from '../promises'
+import { useFakePromises, clearFakePromises, runNextPromise } from '../promises'
 import {
   forceAllPromisesToResolve,
   forceAllPromisesToReject,
@@ -22,6 +22,8 @@ describe('promiseResolver', () => {
         resolve('ok')
         reject('nope')
       })
+
+    runNextPromise()
 
     test()
       .then(spy)
@@ -48,6 +50,8 @@ describe('promiseResolver', () => {
         expect(err).toBe('nope, because!')
       })
 
+    runNextPromise()
+
     expect(spy).not.toBeCalled()
   })
 
@@ -64,6 +68,8 @@ describe('promiseResolver', () => {
         resolve('ok')
         reject('nope')
       })
+
+    runNextPromise()
 
     test()
       .then(result => {

--- a/src/promises/__tests__/promises.test.js
+++ b/src/promises/__tests__/promises.test.js
@@ -1,4 +1,5 @@
 import { useFakePromises, clearFakePromises } from '../promises'
+import promiseQueue from '../promiseQueue'
 import MockPromise from '../mocks/Promise.mock'
 import { noop } from '../../utils/other.utils'
 
@@ -21,9 +22,11 @@ describe('promises', () => {
         expect(result).toBe('Hello')
       })
 
-      rejectedPromise().catch(result => {
-        expect(result).toBe('Nope')
+      rejectedPromise().catch(reason => {
+        expect(reason).toBe('Nope')
       })
+
+      promiseQueue.runAllPromises()
     })
 
     test('Can clear mocked global Promise', () => {
@@ -44,6 +47,8 @@ describe('promises', () => {
       testPromise().then(result => {
         expect(result).toBe('Hello')
       })
+
+      promiseQueue.runAllPromises()
     })
 
     test('Can mock Promises.reject', () => {
@@ -54,6 +59,8 @@ describe('promises', () => {
       testPromise().catch(result => {
         expect(result).toBe('OMG')
       })
+
+      promiseQueue.runAllPromises()
     })
 
     test('Can be resolved with Jest expect', () => {
@@ -104,6 +111,8 @@ describe('promises', () => {
       testPromise().catch(result => {
         expect(result).toBeTruthy()
       })
+
+      promiseQueue.runAllPromises()
     })
 
     test('Promise.resolve can correctly handle catch', () => {
@@ -118,6 +127,8 @@ describe('promises', () => {
       testPromise().catch(result => {
         expect(result).toBeTruthy()
       })
+
+      promiseQueue.runAllPromises()
     })
 
     test('Promise.reject can correctly handle then', () => {
@@ -134,6 +145,8 @@ describe('promises', () => {
           expect(result).toBeTruthy()
         })
         .catch(noop)
+
+      promiseQueue.runAllPromises()
     })
 
     test('Promise.reject can correctly handle reject', () => {
@@ -148,6 +161,8 @@ describe('promises', () => {
       testPromise().then(result => {
         expect(result).toBeTruthy()
       })
+
+      promiseQueue.runAllPromises()
     })
   })
 
@@ -164,6 +179,8 @@ describe('promises', () => {
       Promise.all([one, two, three]).then(values => {
         expect(values).toEqual(['one', 'two', 'three'])
       })
+
+      promiseQueue.runAllPromises()
     })
 
     test('Can catch results', () => {
@@ -174,6 +191,8 @@ describe('promises', () => {
       Promise.all([one, two, three]).catch(values => {
         expect(values).toEqual('three')
       })
+
+      promiseQueue.runAllPromises()
     })
   })
 })

--- a/src/promises/mocks/Promise.mock.js
+++ b/src/promises/mocks/Promise.mock.js
@@ -29,7 +29,6 @@ function Promise(fn) {
   this.process = function() {
     doResolve(fn, this)
   }
-  doResolve(fn, this)
 
   if (!fn.isThen) {
     promiseQueue.add(this)
@@ -134,16 +133,16 @@ function doResolve(fn, self) {
   try {
     fn(
       function(value) {
+        resolveValue = value
         if (done) return
         done = true
         resolve(self, promiseResolver.process(value))
-        resolveValue = value
       },
       function(reason) {
+        rejectReason = reason
         if (done) return
         done = true
         reject(self, promiseResolver.process(reason))
-        rejectReason = reason
       },
     )
     promiseQueue.remove(self)

--- a/src/promises/promiseQueue.ts
+++ b/src/promises/promiseQueue.ts
@@ -1,10 +1,15 @@
 class PromiseQueue {
   queue: Array<unknown> = []
+  runImmediately: boolean = false
   length: number = 0
 
   add(promise) {
     this.queue = [...this.queue, promise]
     this.length = this.queue.length
+
+    if (this.runImmediately) {
+      promise.process()
+    }
   }
 
   remove(promise) {
@@ -15,10 +20,34 @@ class PromiseQueue {
   clear() {
     this.queue = []
     this.length = 0
+    this.runImmediately = false
   }
 
   debug() {
     console.log(this.queue)
+  }
+
+  getNextPromise() {
+    return this.queue[0]
+  }
+
+  runNextPromise() {
+    const promise = this.getNextPromise()
+    if (promise) {
+      // @ts-ignore
+      promise.process()
+    }
+  }
+
+  runAllPromises() {
+    this.queue.forEach(promise => {
+      // @ts-ignore
+      promise.process()
+    })
+  }
+
+  runPromisesImmediately() {
+    this.runImmediately = true
   }
 }
 

--- a/src/promises/promises.ts
+++ b/src/promises/promises.ts
@@ -14,6 +14,12 @@ export const clearFakePromises = () => {
   promiseQueue.clear()
 }
 
+export const runNextPromise = () => promiseQueue.runNextPromise()
+export const runAllPromises = () => promiseQueue.runAllPromises()
+
+export const runPromisesImmediately = () =>
+  promiseQueue.runPromisesImmediately()
+
 export const forceAllPromisesToResolve = callback => {
   promiseResolver.processWith('resolve')
   promiseResolver.addHandler(callback)

--- a/src/types/Cy.types.ts
+++ b/src/types/Cy.types.ts
@@ -87,7 +87,8 @@ export type Cy = {
   useFakeTimers(): void
 
   /**
-   * Mocks the global Promise. Ensures that all Promises immediately resolve synchronously.
+   * Mocks the global Promise. Ensures that all Promises process synchronously.
+   * Promisees do not immediately invoke. They are added to a Mock Promise queue.
    * This is typically added to beforeEach. The mock promises are automatically restored afterEach test.
    *
    * Async/Await is not supported for Mock Promises.
@@ -96,6 +97,38 @@ export type Cy = {
    * cy.useFakePromises()
    */
   useFakePromises(): void
+
+  /**
+   * Forces all Mock Promises to invoke immediately. Used with cy.useFakePromises()
+   * Async/Await is not supported for Mock Promises.
+   *
+   * @example
+   * cy.useFakePromises()
+   * cy.runPromisesImmediately()
+   */
+  runPromisesImmediately(): void
+
+  /**
+   * Processes the next Promise immediately. Used with cy.useFakePromises.
+   * Using cy.runPromisesImmediately() by-passes this method.
+   *
+   * Async/Await is not supported for Mock Promises.
+   *
+   * @example
+   * cy.runNextPromise()
+   */
+  runNextPromise(): void
+
+  /**
+   * Processes the next Promise immediately. Used with cy.useFakePromises.
+   * Using cy.runPromisesImmediately() by-passes this method.
+   *
+   * Async/Await is not supported for Mock Promises.
+   *
+   * @example
+   * cy.runAllPromises()
+   */
+  runAllPromises(): void
 
   /**
    * Restores the mocked global Promise to the original Promise implementation. Used for clean up after.


### PR DESCRIPTION
## Promise: Adding run commands + queuing system

This update adjusts how Cyan handles mock promises. Once `cy.useFakePromises` is instantiated, the global `Promise` class is mocked (like before). However, instead of immediately instantiating, they are added to a queue, to simulate how actual promises are offset to a separate callstack.

Once in the queue, they can be executed incrementally!

This can be done with the new `cy.runNextPromise()` method.
To execute all queued promises, you can run `cy.runAllPromises()`.

To keep the previous behaviour of always immediately invoking promises, you can use the new `cy.runPromisesImmediately` after `cy.useFakePromises`.