### PR TITLE
Wrap data attribute in quotes

### DIFF
--- a/src/__tests__/cy.test.js
+++ b/src/__tests__/cy.test.js
@@ -35,6 +35,17 @@ describe('cy', () => {
       expect(cy.getByCy('hello').isTagName('aside')).toBe(true)
     })
 
+    test('Can get a DOM Node by data-cy with special characters inside', () => {
+      cy.render(
+        <main>
+          <section />
+          <aside data-cy="hello.you" />
+        </main>,
+      )
+
+      expect(cy.getByCy('hello.you').isTagName('aside')).toBe(true)
+    })
+
     test('Can get an DOM Node by data-cy by chaining', () => {
       cy.render(
         <main>

--- a/src/utils/selector.utils.js
+++ b/src/utils/selector.utils.js
@@ -27,7 +27,7 @@ export const get = selector => {
   return []
 }
 
-export const getByCy = selector => get(`[data-cy=${selector}]`)
+export const getByCy = selector => get(`[data-cy="${selector}"]`)
 
 export const getByText = (text, node = document.body) => {
   return baseGetByText(node, text)


### PR DESCRIPTION
## Fix cy.getByCy

This update provides a fix for the `cy.getByCy` method which allows for the use of special characters in the data selector.

The `cy.getByCy` method did not work with data selectors with special characters, like a `.` or `#`, because it produced an invalid selector. For example, `[data-cy=hello.you]` is an invalid selector. We need to wrap the attribute in quotes to guard against this. For example, `[data-cy="hello.you"]` is a valid selector.

With this fix, both `cy.getByCy('hello')` and `cy.getByCy('hello.you')` will work.