### PR TITLE
CleanUp: Adjust DOM cleanUp and Remove RAF Polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/cyan",
-  "version": "0.4.3",
+  "version": "0.5.0-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/cyan",
-  "version": "0.4.3",
+  "version": "0.5.0-0",
   "description": "Cypress-like Testing for React + JSDOM",
   "main": "dist/index.js",
   "private": false,

--- a/scripts/setupTests.js
+++ b/scripts/setupTests.js
@@ -1,3 +1,11 @@
 import setupTests from '../src/setupTests'
 
+beforeEach(() => {
+  jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => cb())
+})
+
+afterEach(() => {
+  window.requestAnimationFrame.mockRestore()
+})
+
 setupTests()

--- a/src/cleanUp.js
+++ b/src/cleanUp.js
@@ -6,7 +6,6 @@ const cleanUp = () => {
   if (root) {
     ReactDOM.unmountComponentAtNode(root)
   }
-  document.body.innerHTML = ''
 }
 
 export default cleanUp

--- a/src/domCleanUp.js
+++ b/src/domCleanUp.js
@@ -1,0 +1,5 @@
+const domCleanUp = () => {
+  document.body.innerHTML = ''
+}
+
+export default domCleanUp

--- a/src/polyfills/jsdom.polyfills.js
+++ b/src/polyfills/jsdom.polyfills.js
@@ -1,7 +1,5 @@
 const setupJSDOM = () => {
   beforeEach(() => {
-    jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => cb())
-
     window.getSelection = () => {
       return {
         addRange: () => ({}),
@@ -25,7 +23,6 @@ const setupJSDOM = () => {
   afterEach(() => {
     window.getSelection = undefined
     window.scrollTo = undefined
-    window.requestAnimationFrame.mockRestore()
     document.createRange = undefined
     document.execCommand = undefined
   })

--- a/src/render.js
+++ b/src/render.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom'
 import { MemoryRouter as Router } from 'react-router'
 import { Provider } from 'react-redux'
 import cleanUp from './cleanUp'
+import domCleanUp from './domCleanUp'
 import debug from './debug'
 import { getStore } from './store'
 import { runAllTimers } from './timers'
@@ -18,7 +19,13 @@ export const wrapWithProvider = WrappedComponent => {
   )
 }
 
+const renderCleanUp = () => {
+  cleanUp()
+  domCleanUp()
+}
+
 const render = (WrappedComponent = null) => {
+  renderCleanUp()
   // Create the root node for ReactDOM to mount to
   const root = createRootNode()
   document.body.appendChild(root)
@@ -32,7 +39,7 @@ const render = (WrappedComponent = null) => {
     debug,
     html: debug,
     WrappedComponent,
-    cleanUp,
+    cleanUp: renderCleanUp,
   }
 }
 


### PR DESCRIPTION
## CleanUp: Adjust DOM cleanUp and Remove RAF Polyfill

This update fixes the `setupTests()` function to ensure that
`document.body.innerHTML` is left untouched. The `requestAnimationFrame`
mock polyfill has also been removed from `setupTests()`.

Both of these updates have been added to ensure smoother integration into
older systems.