### PR TITLE
SetupTests: Add requestAnimationFrame back

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,5 +5,6 @@ module.exports = Object.assign(jestConfig, {
     ...jestConfig.collectCoverageFrom,
     '!src/polyfills/**/*.{js,jsx,ts,tsx}',
     '!src/promises/mocks/**/*.{js,jsx,ts,tsx}',
+    '!src/mocks/**/*.{js,jsx,ts,tsx}',
   ],
 })

--- a/scripts/setupTests.js
+++ b/scripts/setupTests.js
@@ -1,11 +1,3 @@
 import setupTests from '../src/setupTests'
 
-beforeEach(() => {
-  jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => cb())
-})
-
-afterEach(() => {
-  window.requestAnimationFrame.mockRestore()
-})
-
 setupTests()

--- a/src/mocks/index.js
+++ b/src/mocks/index.js
@@ -1,0 +1,3 @@
+export {
+  default as mockRequestAnimationFrame,
+} from './requestAnimationFrame.mock'

--- a/src/mocks/requestAnimationFrame.mock.js
+++ b/src/mocks/requestAnimationFrame.mock.js
@@ -1,0 +1,24 @@
+const mockImplementation = () => {
+  // Cache the mock implementation in scope
+  let raf
+
+  beforeEach(() => {
+    raf = jest
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation(function(cb) {
+        // Handle edge-case where the callback is a Function: schedule.
+        // Otherwise, a maximum callstack issue happens, and Jest blows up.
+        if (cb.name !== 'schedule') {
+          return cb()
+        }
+      })
+  })
+
+  afterEach(() => {
+    // Restore and reset
+    raf && raf.mockRestore()
+    raf = null
+  })
+}
+
+export default mockImplementation

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,6 +1,7 @@
 import cleanUp from './cleanUp'
 import { completelyResetStore, resetStore } from './store'
 import { resetConfig } from './configuration'
+import { mockRequestAnimationFrame } from './mocks'
 import { clearFakePromises } from './promises'
 import promiseQueue from './promises/promiseQueue'
 import promiseResolver from './promises/promiseResolver'
@@ -8,6 +9,7 @@ import setupJSDOM from './polyfills/jsdom.polyfills'
 
 const setupTests = () => {
   setupJSDOM()
+  mockRequestAnimationFrame()
 
   beforeEach(() => {
     promiseResolver.clear()


### PR DESCRIPTION
## SetupTests: Add requestAnimationFrame back

This update adds `window.requestAnimationFrame` mocking back to setupTests.
This was briefly removed to help integrate with the main application.
However, rAF mocking is very much a thing that is required for more complicated
React components (e.g. Popover, Dropdown, etc...).

The solution involved caching the mock implementation as a variable, to make
it more reliable to `mockRestore`. Also, to handle the case of the callback
being a `schedule` function, to prevent the maximum callstack issue.