### PR TITLE
setupTests: Add mock IntersectionObserver

### DIFF
--- a/src/polyfills/jsdom.polyfills.js
+++ b/src/polyfills/jsdom.polyfills.js
@@ -1,12 +1,27 @@
 const setupJSDOM = () => {
   beforeEach(() => {
+    /**
+     * window
+     */
+    window.IntersectionObserver = () => ({
+      disconnect: () => null,
+      observe: () => null,
+      takeRecords: () => null,
+      unobserve: () => null,
+    })
+
     window.getSelection = () => {
       return {
         addRange: () => ({}),
         removeAllRanges: () => ({}),
       }
     }
+
     window.scrollTo = () => null
+
+    /**
+     * document
+     */
     document.createRange = () => ({
       setStart: () => {},
       setEnd: () => {},
@@ -21,8 +36,16 @@ const setupJSDOM = () => {
   })
 
   afterEach(() => {
+    /**
+     * window
+     */
+    window.IntersectionObserver = undefined
     window.getSelection = undefined
     window.scrollTo = undefined
+
+    /**
+     * document
+     */
     document.createRange = undefined
     document.execCommand = undefined
   })


### PR DESCRIPTION
## setupTests: Add mock IntersectionObserver

This update adds a mock implementation of IntersectionObserver.
The IntersectionObserver methods just return null.

Resolves: https://github.com/helpscout/cyan/issues/8