### PR TITLE
Debug: Add debugByCy

### DIFF
--- a/docs/api/debugging.md
+++ b/docs/api/debugging.md
@@ -45,7 +45,7 @@ test('My component can render', () => {
 
 ## debug
 
-`Function(): void`
+`Function(selector?: string): void`
 
 [Logs](https://developer.mozilla.org/en-US/docs/Web/API/Console/log) the rendered within for `document.body`.<br />
 No need to call `console.log`. The `debug()` method does this automatically!
@@ -61,6 +61,31 @@ test('My component can render', () => {
   cy.debug()
   // The following is logged in your Jest test runner:
   // <div class="sample-component"></div>
+})
+```
+
+## debugByCy
+
+`Function(selector?: string): void`
+
+[Logs](https://developer.mozilla.org/en-US/docs/Web/API/Console/log) the rendered from a matching `data-cy` selector.<br />
+No need to call `console.log`. The `debug()` method does this automatically!
+
+#### Example
+
+```jsx
+const SampleComponent = () => (
+  <div className="sample-component">
+    <div data-cy="InnerSampleComponent" />
+  </div>
+)
+
+test('My component can render', () => {
+  cy.render(<SampleComponent />)
+
+  cy.debugByCy('InnerSampleComponent')
+  // The following is logged in your Jest test runner:
+  // <div data-cy="InnerSampleComponent"></div>
 })
 ```
 

--- a/src/__tests__/debug.test.js
+++ b/src/__tests__/debug.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import debug from '../debug'
+import { debug, debugByCy } from '../debug'
 import { cy } from '../index'
 
 describe('debug', () => {
@@ -56,5 +56,31 @@ describe('debug', () => {
 
     expect(spy).toHaveBeenCalledWith('<main>\n  <p>Hello</p>\n</main>')
     expect(warnSpy).toHaveBeenCalled()
+  })
+})
+
+describe('debugByCy', () => {
+  let spy
+  let warnSpy
+
+  beforeEach(() => {
+    spy = jest.spyOn(global.console, 'log').mockImplementation(() => {})
+    warnSpy = jest.spyOn(global.console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    spy.mockRestore()
+    warnSpy.mockRestore()
+  })
+
+  test('Logs HTML from a data-cy attribute', () => {
+    cy.render(
+      <main>
+        <span data-cy="Hello">Hi</span>
+      </main>,
+    )
+    debugByCy('Hello')
+
+    expect(spy).toHaveBeenCalledWith('<span data-cy="Hello">Hi</span>')
   })
 })

--- a/src/__tests__/debug.test.js
+++ b/src/__tests__/debug.test.js
@@ -83,4 +83,11 @@ describe('debugByCy', () => {
 
     expect(spy).toHaveBeenCalledWith('<span data-cy="Hello">Hi</span>')
   })
+
+  test('Logs document.body if no selector', () => {
+    cy.render(<span data-cy="Hello">Hi</span>)
+    debugByCy()
+
+    expect(spy).toHaveBeenCalledWith('<span data-cy="Hello">Hi</span>')
+  })
 })

--- a/src/cy.ts
+++ b/src/cy.ts
@@ -4,7 +4,7 @@ import { get, getByCy, getByText } from './utils/selector.utils'
 import { typeCommand } from './utils/keyEvent.utils'
 import cleanUp from './cleanUp'
 import domCleanUp from './domCleanUp'
-import debug from './debug'
+import { debug, debugByCy } from './debug'
 import delay from './delay'
 import inspect from './inspector'
 import * as timerFunctions from './timers'
@@ -29,6 +29,7 @@ const cy: Cy = {
   cleanUp,
   domCleanUp,
   debug,
+  debugByCy,
   delay,
   inspect,
   render,

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -1,7 +1,7 @@
 import { pretty } from './utils/pretty.utils'
 import { getDocumentHTML } from './utils/render.utils'
 
-const debug = (selector?: string, options?: any) => {
+export const debug = (selector?: string, options?: any) => {
   let html = getDocumentHTML()
 
   if (selector) {
@@ -18,6 +18,14 @@ const debug = (selector?: string, options?: any) => {
     }
   }
   console.log(pretty(html, options))
+}
+
+export const debugByCy = (selector?: string, options?: any) => {
+  if (!selector) {
+    debug(selector, options)
+  } else {
+    debug(`[data-cy="${selector}"]`, options)
+  }
 }
 
 export default debug

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ export { default as cy } from './cy'
 
 export { default as cleanUp } from './cleanUp'
 export { default as domCleanUp } from './domCleanUp'
-export { default as debug } from './debug'
+export { debug, debugByCy } from './debug'
 export { default as fireEvent } from './fireEvent'
 export { default as render } from './render'
 export { default as setupTests } from './setupTests'

--- a/src/types/Cy.types.ts
+++ b/src/types/Cy.types.ts
@@ -82,6 +82,17 @@ export type Cy = {
   debug(selector?: string, options?: any): void
 
   /**
+   * Logs the html of a DOM element matching a data-cy selector.
+   *
+   * @param {string} selector The data-cy selector.
+   * @param {Object} options Options for printing (js-beautify).
+   *
+   * @example
+   * cy.debugByCy('Button')
+   */
+  debugByCy(selector?: string, options?: any): void
+
+  /**
    * Runs all immediates, ticks, timers, and Mock Promises.
    *
    * @example


### PR DESCRIPTION
## Debug: Add debugByCy

This update adds a new `debugByCy` method. It runs the `cy.debug()` print
method, but scopes the HTML based on a matching `data-cy` selector, similar
to `cy.getByCy`.