### PR TITLE
RenderWrapper: Add getInstance method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/cyan",
-  "version": "0.11.1",
+  "version": "0.11.2-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/cyan",
-  "version": "0.11.1",
+  "version": "0.11.2-0",
   "description": "Cypress-like Testing for React + JSDOM",
   "main": "dist/index.js",
   "private": false,

--- a/src/render/RenderWrapper.tsx
+++ b/src/render/RenderWrapper.tsx
@@ -12,6 +12,7 @@ class RenderWrapper extends Cyan {
   Component: any
   WrappedComponent: any
   initialProps: any
+  __instance: any
   root: HTMLElement
 
   constructor(Component: any) {
@@ -51,6 +52,10 @@ class RenderWrapper extends Cyan {
     return this
   }
 
+  getInstance() {
+    return this.__instance
+  }
+
   setProps(props = this.initialProps) {
     this.render(props)
     return this
@@ -78,7 +83,8 @@ class RenderWrapper extends Cyan {
 
   render(props) {
     const Component = this.WrappedComponent
-    ReactDOM.render(<Component {...props} />, this.root)
+    this.__instance = <Component {...props} />
+    ReactDOM.render(this.__instance, this.root)
     return this
   }
 }

--- a/src/render/__tests__/render.test.js
+++ b/src/render/__tests__/render.test.js
@@ -139,4 +139,13 @@ describe('render', () => {
     expect(cy.get('div').exists()).not.toBeTruthy()
     expect(cy.get('span').exists()).toBeTruthy()
   })
+
+  test('Can retrieve the component instance', () => {
+    const wrapper = cy.render(<div>Hello</div>)
+    const instance = wrapper.getInstance()
+
+    expect(instance.$$typeof).toBeTruthy()
+    expect(instance.type).toBeTruthy()
+    expect(instance.props.children).toBe('Hello')
+  })
 })

--- a/src/types/RenderWrapper.interface.types.ts
+++ b/src/types/RenderWrapper.interface.types.ts
@@ -2,6 +2,17 @@ import CyanInterface from './Cyan.interface.types'
 
 export interface RenderWrapperInterface extends CyanInterface {
   /**
+   * Gets the React rendered component instance.
+   *
+   * @returns {React.Component} The rendered Component instance.
+   *
+   * @example
+   * const wrapper = cy.render(<div />)
+   * wrapper.getInstance()
+   */
+  getInstance(): any
+
+  /**
    * Sets props for the Component and re-renders it into the DOM.
    *
    * @param {Object} props The props to set.


### PR DESCRIPTION
## RenderWrapper: Add getInstance method

This update adds a `.getInstance()` method to the `cy.render()` class
instance. This allows for finer grain component checking, similar to
what you may get in Enzyme.