### PR TITLE
Add findByCy method

### DIFF
--- a/docs/api/traversing.md
+++ b/docs/api/traversing.md
@@ -126,6 +126,22 @@ Get descendent DOM elements that match a specific selector.
 cy.get('ul').find('li.item')
 ```
 
+## findByCy
+
+`Function(selector: string): Cyan instance`
+
+Get descendent DOM elements that match a specific `data-cy` selector.
+
+#### Parameters
+
+- `selector` `{string}` A selector used for descendent matching.
+
+#### Example
+
+```javascript
+cy.get('ul').findByCy('Item')
+```
+
 ## first
 
 Get the first DOM element from the main DOM elements.

--- a/src/commands/__tests__/selector.commands.test.js
+++ b/src/commands/__tests__/selector.commands.test.js
@@ -157,6 +157,25 @@ describe('commands/selector', () => {
     })
   })
 
+  describe('findByCy', () => {
+    test('Can find matches', () => {
+      cy.render(
+        <ul>
+          <li className="list-item">One</li>
+          <li>Two</li>
+          <li className="list-item" data-cy="Item">
+            Three
+          </li>
+        </ul>,
+      )
+
+      const assert = cy.get('ul').findByCy('Item')
+
+      expect(assert.length).toBe(1)
+      expect(assert.first().text()).toBe('Three')
+    })
+  })
+
   describe('first', () => {
     test('Returns the first item', () => {
       cy.render(

--- a/src/commands/selector.commands.ts
+++ b/src/commands/selector.commands.ts
@@ -78,6 +78,22 @@ function filter(selector) {
  * @returns {Cyan} The Cyan instance.
  *
  * @example
+ * cy.get('ul').findByCy('Item')
+ */
+function findByCy(selector) {
+  const cySelector = `[data-cy="${selector}"]`
+  const node = this.__getNode('findByCy', cySelector)
+  this.get(node.querySelectorAll(cySelector))
+  return this
+}
+
+/**
+ * Get descendent DOM elements that match a specific data-cy selector.
+ *
+ * @param {string} selector A selector used for descendent matching.
+ * @returns {Cyan} The Cyan instance.
+ *
+ * @example
  * cy.get('ul').find('li.item')
  */
 function find(selector) {
@@ -175,6 +191,7 @@ const commands = {
   eq,
   filter,
   find,
+  findByCy,
   first,
   last,
   next,

--- a/src/types/Cyan.interface.types.ts
+++ b/src/types/Cyan.interface.types.ts
@@ -510,6 +510,17 @@ export interface CyanInterface extends CyanEventInterface {
   find(selector: string): this
 
   /**
+   * Get descendent DOM elements that match a specific selector.
+   *
+   * @param {string} selector A selector used for descendent matching.
+   * @returns {Cyan} The Cyan instance.
+   *
+   * @example
+   * cy.get('ul').findByCy('Item')
+   */
+  findByCy(selector: string): this
+
+  /**
    * Get the first DOM element from the main DOM elements.
    *
    * @returns {Cyan} The Cyan instance.


### PR DESCRIPTION
## Add findByCy method

This update adds a new method, `findByCy`. After the initial `get` or
`getByCy`, this method can be used to (easily) find DOM selectors that
match a specific `data-cy` query.


## findByCy

`Function(selector: string): Cyan instance`

Get descendent DOM elements that match a specific `data-cy` selector.

#### Parameters

- `selector` `{string}` A selector used for descendent matching.

#### Example

```javascript
cy.get('ul').findByCy('Item')
```

Resolves: https://github.com/helpscout/cyan/issues/15